### PR TITLE
JOS-35: Return CORS Response headers if X-AUTH-TOKEN is used

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1052,6 +1052,11 @@ OPTION(rgw_multipart_part_upload_limit, OPT_INT, 1024) // parts limit in multipa
 OPTION(rgw_olh_pending_timeout_sec, OPT_INT, 3600) // time until we retire a pending olh change
 OPTION(rgw_user_max_buckets, OPT_U32, 1000) // global option to set max buckets count for all user
 
+OPTION(rgw_enable_cors_response_headers, OPT_BOOL, true) // send cors response headers in case of a token based request
+OPTION(rgw_cors_allowed_origin, OPT_STR, "http://console.staging.jiocloudservices.com, http://console.jiocloudservices.com") // cors allowed domains
+OPTION(rgw_cors_allowed_methods, OPT_STR, "GET, PUT, HEAD, POST, DELETE, COPY") // cors allowed methods
+
+
 OPTION(mutex_perf_counter, OPT_BOOL, false) // enable/disable mutex perf counter
 OPTION(throttler_perf_counter, OPT_BOOL, true) // enable/disable throttler perf counter
 

--- a/src/rgw/rgw_cors.h
+++ b/src/rgw/rgw_cors.h
@@ -34,6 +34,8 @@
                          RGW_CORS_COPY)
 
 #define CORS_MAX_AGE_INVALID ((uint32_t)-1)
+#define JCS_CORS_CONSOLE_DOMAIN "console.jcs.com"
+#define JCS_CORS_CONSOLE_METHODS "GET, PUT, HEAD, POST, DELETE, COPY"
 
 class RGWCORSRule
 {

--- a/src/rgw/rgw_cors.h
+++ b/src/rgw/rgw_cors.h
@@ -34,8 +34,6 @@
                          RGW_CORS_COPY)
 
 #define CORS_MAX_AGE_INVALID ((uint32_t)-1)
-#define JCS_CORS_CONSOLE_DOMAIN "console.jcs.com"
-#define JCS_CORS_CONSOLE_METHODS "GET, PUT, HEAD, POST, DELETE, COPY"
 
 class RGWCORSRule
 {


### PR DESCRIPTION
- returning the following headers in case the request has X-Auth-Token header and the request is successful
  Access-Control-Allow-Origin: console.jcs.com
  Access-Control-Allow-Methods: GET, PUT, HEAD, POST, DELETE, COPY
