### PR TITLE
JOS44: Print IAM request and response headers in DSS logs 

### DIFF
--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -50,6 +50,7 @@ inline std::ostream& operator<<(std::ostream& out, _bad_endl_use_dendl_t) {
     }									\
     ceph::log::Entry *_dout_e = cct->_log->create_entry(v, sub);	\
     ostream _dout_os(&_dout_e->m_streambuf);				\
+    _dout_os << __FUNCTION__;                                           \
     CephContext *_dout_cct = cct;					\
     std::ostream* _dout = &_dout_os;
 

--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -50,7 +50,6 @@ inline std::ostream& operator<<(std::ostream& out, _bad_endl_use_dendl_t) {
     }									\
     ceph::log::Entry *_dout_e = cct->_log->create_entry(v, sub);	\
     ostream _dout_os(&_dout_e->m_streambuf);				\
-    _dout_os << __FUNCTION__;                                           \
     CephContext *_dout_cct = cct;					\
     std::ostream* _dout = &_dout_os;
 

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -84,7 +84,14 @@ int RGWHTTPClient::process(const char *method, const char *url)
 
   curl_handle = curl_easy_init();
 
-  dout(20) << "sending request to " << url << dendl;
+  dout(20) << "RGWHTTPClient::process sending request to " << url << dendl;
+  list<pair<string, string> >::iterator it;
+  for (it = headers.begin(); it != headers.end(); it++) {
+      dout(0) << "DSS INFO: IAM request header: "
+              << (*it).first
+              << " : "
+              << (*it).second << dendl;
+  }
 
   curl_slist *h = headers_to_slist(headers);
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2359,8 +2359,10 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_s3token(const string& auth_id,
   credentials.close_section();
   std::stringstream os;
   credentials.flush(os);
+  tx_buffer.clear();
   set_tx_buffer(os.str());
   dout(0) << "DSS INFO: Outbound json: " << os.str() << dendl;
+  dout(0) << "DSS INFO: Actual TX buffer: " << tx_buffer.c_str() << dendl;
 
   /* send request */
   const clock_t begin_time = clock();
@@ -2372,13 +2374,13 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_s3token(const string& auth_id,
     return -EPERM;
   }
   dout(0) << "DSS INFO: Printing RX buffer: " << rx_buffer.c_str() << dendl;
+  dout(0) << "DSS INFO: Printing RX headers: " << rx_headers_buffer.c_str() << dendl;
 
   /* now parse response */
   if (response.parse(cct, rx_buffer) < 0) {
     dout(2) << "DSS ERROR: keystone:  signature response parsing failed" << dendl;
     return -EPERM;
   }
-  dout(0) << "DSS INFO: Printing RX buffer: " << rx_buffer.c_str() << dendl;
 
   /* Check if the response is okay */
   if ((response.user.id).empty()   ||
@@ -2416,6 +2418,7 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_consoleToken(const string& acti
   /* set required headers for keystone request */
   append_header("X-Auth-Token", token);
   append_header("Content-Type", "application/json");
+  dout(0) << "DSS INFO: Token flow setting tx buffer" << dendl;
   set_tx_buffer("{ }"); // DSS: Need a blank json else IAM will reject
 
 
@@ -2495,6 +2498,7 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_consoleToken(const string& acti
   keystone_url.append("&resource=");
   keystone_url.append(resource_str);
   tx_buffer.clear();
+  dout(0) << "DSS INFO: Token flow setting tx buffer in second call" << dendl;
   set_tx_buffer("{ }"); // DSS: Need a blank json else IAM will reject
 
   dout(0) << "DSS INFO: Validating token" << dendl;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2454,15 +2454,15 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_consoleToken(const string& acti
           dout(0) << "DSS ERROR COPY SRC: Token keystone: token validation ERROR: " << rx_buffer.c_str() << dendl;
           return -EPERM;
       }
+
       dout(0) << "DSS INFO COPY SRC: Printing RX buffer: " << rx_buffer.c_str() << dendl;
+      dout(0) << "DSS INFO: Printing RX headers: " << rx_headers_buffer.c_str() << dendl;
 
       /* now parse response */
       if (response.parse(cct, rx_buffer) < 0) {
           dout(0) << "DSS ERROR COPY SRC: Token keystone: token parsing failed" << dendl;
-          dout(0) << "DSS INFO: Printing RX buffer: " << rx_buffer.c_str() << dendl;
           return -EPERM;
       }
-      dout(0) << "DSS INFO COPY SRC: Printing RX buffer: " << rx_buffer.c_str() << dendl;
 
       /* Check if the response is okay */
       if ((response.user.id).empty()   ||
@@ -2517,13 +2517,14 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_consoleToken(const string& acti
     return -EPERM;
   }
 
+  dout(0) << "DSS INFO: Printing RX buffer: " << rx_buffer.c_str() << dendl;
+  dout(0) << "DSS INFO: Printing RX headers: " << rx_headers_buffer.c_str() << dendl;
+
   /* now parse response */
   if (response.parse(cct, rx_buffer) < 0) {
     dout(0) << "DSS ERROR: Token keystone: token parsing failed" << dendl;
-    dout(0) << "DSS INFO: Printing RX buffer: " << rx_buffer.c_str() << dendl;
     return -EPERM;
   }
-  dout(0) << "DSS INFO: Printing RX buffer: " << rx_buffer.c_str() << dendl;
 
   /* Check if the response is okay */
   if ((response.user.id).empty()   ||

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -295,6 +295,7 @@ public:
 class RGW_Auth_S3_Keystone_ValidateToken : public RGWHTTPClient {
 private:
   bufferlist rx_buffer;
+  bufferlist rx_headers_buffer;
   bufferlist tx_buffer;
   bufferlist::iterator tx_buffer_it;
   list<string> roles_list;
@@ -317,6 +318,7 @@ public:
   }
 
   int receive_header(void *ptr, size_t len) {
+    rx_headers_buffer.append((char *)ptr, len);
     return 0;
   }
   int receive_data(void *ptr, size_t len) {


### PR DESCRIPTION
2016-03-07 13:39:42.851460 7f2e19ffb700  0 DSS INFO: Outbound json: {"credentials":{"access":"c312c8c23a9e45398003b256759cef05"
,"token":"UFVUCk1xdkJsNnU3d2QyYzVnZTQ0eTM1Znc9PQphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0KTW9uLCAwNyBNYXIgMjAxNiAxMzozOTo0MiBHTVQKL3Jqa
WxidWNrZXRzYW5pdHkxNDU3MzU3OTU5Ny9yamlsYnVja2V0c2FuaXR5MTQ1NzM1Nzk1OTdfT0JKXzg=","signature":"01M1Uv+KLOOLUCuQUwCyXsMQCxw=","ac
tion_resource_list":[{"action":"jrn:jcs:dss:PutObject","resource":"jrn:jcs:dss::Bucket:rjilbucketsanity14573579597","implicit_a
llow":"False"}]}}
2016-03-07 13:39:42.851471 7f2e19ffb700  0 DSS INFO: Actual TX buffer: {"credentials":{"access":"c312c8c23a9e45398003b256759cef
05","token":"UFVUCk1xdkJsNnU3d2QyYzVnZTQ0eTM1Znc9PQphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0KTW9uLCAwNyBNYXIgMjAxNiAxMzozOTo0MiBHTVQKL3
JqaWxidWNrZXRzYW5pdHkxNDU3MzU3OTU5Ny9yamlsYnVja2V0c2FuaXR5MTQ1NzM1Nzk1OTdfT0JKXzg=","signature":"01M1Uv+KLOOLUCuQUwCyXsMQCxw=",
"action_resource_list":[{"action":"jrn:jcs:dss:PutObject","resource":"jrn:jcs:dss::Bucket:rjilbucketsanity14573579597","implici
t_allow":"False"}]}}
2016-03-07 13:39:42.851535 7f2e19ffb700 20 RGWHTTPClient::process sending request to https://iam.ind-west-1.staging.jiocloudser
vices.com:35357/v3/sign-auth
2016-03-07 13:39:42.851540 7f2e19ffb700  0 DSS INFO: IAM request header: Content-Type : application/json
2016-03-07 13:39:43.058096 7f2e19ffb700  0 DSS INFO: Keystone response time (milliseconds): 100
2016-03-07 13:39:43.058337 7f2e19ffb700  0 DSS INFO: Printing RX buffer: {"token_id": "4e5314cadc6f4bce93fe817ef9213f34", "user
_id": "08d9079e37ca4750ae1b223af8869f92", "account_id": "08d9079e37ca4750ae1b223af8869f92", "user_type": "regular"}
2016-03-07 13:39:43.058381 7f2e19ffb700  0 DSS INFO: Printing RX headers: HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Date: Mon, 07 Mar 2016 13:39:43 GMT  
Server: Apache/2.4.7 (Ubuntu)
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: Accept, Content-Type, X-Auth-Token, X-Subject-Token
Access-Control-Expose-Headers: Accept, Content-Type, X-Auth-Token, X-Subject-Token
Access-Control-Allow-Methods: GET POST OPTIONS PUT DELETE PATCH
Vary: X-Auth-Token
Content-Type: application/json
Content-Length: 169
X-Openstack-Request-Id: req-66fe7782-4996-4971-83b0-c106a8d91600
Via: 1.1 iam.ind-west-1.staging.jiocloudservices.com:35357
Connection: close

2016-03-07 13:39:43.058494 7f2e19ffb700  5 DSS INFO: keystone validated signature for (root account id : user id) 08d9079e37ca4
750ae1b223af8869f92:08d9079e37ca4750ae1b223af8869f92
