### PR TITLE
JOS-35: Return CORS Response headers if X-AUTH-TOKEN is used

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1055,7 +1055,7 @@ OPTION(rgw_user_max_buckets, OPT_U32, 1000) // global option to set max buckets 
 OPTION(rgw_enable_cors_response_headers, OPT_BOOL, true) // send cors response headers in case of a token based request
 OPTION(rgw_cors_allowed_origin, OPT_STR, "http://console.staging.jiocloudservices.com") // cors allowed domains
 OPTION(rgw_cors_allowed_methods, OPT_STR, "GET, PUT, HEAD, POST, DELETE, COPY, OPTIONS") // cors allowed methods
-OPTION(rgw_cors_allowed_headers, OPT_STR, "X-Auth-Token, Content-Disposition") // cors allowed headers
+OPTION(rgw_cors_allowed_headers, OPT_STR, "X-Auth-Token, Content-Disposition, Content-Type") // cors allowed headers
 OPTION(rgw_cors_content_disposition_header, OPT_STR, "Content-Disposition") // cors content disposition HEADER
 OPTION(rgw_cors_content_disposition_header_value, OPT_STR, "attachment") // cors content disposition HEADER value
 


### PR DESCRIPTION
- adding Content-Type as allowed headers in default config
