### PR TITLE
JOS 47: Accept JCS in authentication header 

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1059,6 +1059,9 @@ OPTION(rgw_cors_allowed_headers, OPT_STR, "X-Auth-Token, Content-Disposition") /
 OPTION(rgw_cors_content_disposition_header, OPT_STR, "Content-Disposition") // cors content disposition HEADER
 OPTION(rgw_cors_content_disposition_header_value, OPT_STR, "attachment") // cors content disposition HEADER value
 
+OPTION(rgw_disable_acl_api, OPT_BOOL, "true")             // disable all acl getters and setters
+OPTION(rgw_keystone_sign_api, OPT_STR, "v3/sign-auth")    // api to validate signature based authentication requests
+OPTION(rgw_keystone_token_api, OPT_STR, "v3/token-auth")  // api to validate token based authentication requests
 
 OPTION(mutex_perf_counter, OPT_BOOL, false) // enable/disable mutex perf counter
 OPTION(throttler_perf_counter, OPT_BOOL, true) // enable/disable throttler perf counter

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2314,7 +2314,7 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_s3token(const string& auth_id,
   if (keystone_url[keystone_url.size() - 1] != '/') {
     keystone_url.append("/");
   }
-  keystone_url.append("v3/sign-auth");
+  keystone_url.append(cct->_conf->rgw_keystone_sign_api);
 
   dout(0) << "DSS INFO: Action string: " << action_str << dendl;
   dout(0) << "DSS INFO: Resource string: " << resource_str << dendl;
@@ -2434,7 +2434,7 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_consoleToken(const string& acti
           keystone_url.append("/");
       }
 
-      keystone_url.append("v3/token-auth");
+      keystone_url.append(cct->_conf->rgw_keystone_token_api);
       keystone_url.append("?action=");
       keystone_url.append(action_str);
       keystone_url.append("&resource=");
@@ -2492,7 +2492,7 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_consoleToken(const string& acti
     keystone_url.append("/");
   }
 
-  keystone_url.append("v3/token-auth");
+  keystone_url.append(cct->_conf->rgw_keystone_token_api);
   keystone_url.append("?action=");
   keystone_url.append(action_str);
   keystone_url.append("&resource=");
@@ -2565,7 +2565,8 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
 
   // Block any ACL request for DSS
   string qstring = (s->info).request_params;
-  if (qstring.compare("acl") == 0) {
+  //cct->_conf->rgw_disable_acl_api;
+  if (store->ctx()->_conf->rgw_disable_acl_api && (qstring.compare("acl") == 0)) {
       dout(0) << "DSS INFO: ACL requests are not supported" << dendl;
       return -EPERM;
   }
@@ -2612,7 +2613,7 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
               return 0;
           }
       } else {
-          if (strncmp(s->http_auth, "AWS ", 4))
+          if ((strncmp(s->http_auth, "AWS ", 4) || (strncmp(s->http_auth, "JCS ", 4)))
               return -EINVAL;
           string auth_str(s->http_auth + 4);
           int pos = auth_str.rfind(':');

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2613,7 +2613,8 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
               return 0;
           }
       } else {
-          if ((strncmp(s->http_auth, "AWS ", 4) || (strncmp(s->http_auth, "JCS ", 4)))
+          // strncmp returns 0 on match. If even one of AWS or JCS match, dont return -EINVAL.
+          if ((strncmp(s->http_auth, "AWS ", 4)) && (strncmp(s->http_auth, "JCS ", 4)))
               return -EINVAL;
           string auth_str(s->http_auth + 4);
           int pos = auth_str.rfind(':');


### PR DESCRIPTION
RGW now accepts JCS as well as AWS in auth headers.

RGW now has option to turn ACLS on/off

RGW now has options to set IAM APIs for token-auth and sign-auth
# 
# Logs:

root@vm-mac0 ~: python sanperl ./dsscurl_raj.pl --id=iam_user_00 -- http://127.0.0.1:8000
StringToSign='GET

Tue, 08 Mar 2016 08:27:18 +0000
/'
==========exec curl -v -H Date: Tue, 08 Mar 2016 08:27:18 +0000 -H Authorization: AWS 0ef217eff5b146f19759532d3b6ea76a:LpagvRo2e/Q6NRdNnI5l84ub/4U= -L -H content-type:  http://127.0.0.1:8000
==========\* Rebuilt URL to: http://127.0.0.1:8000/
- Hostname was NOT found in DNS cache
-   Trying 127.0.0.1...
- Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
  > GET / HTTP/1.1
  > User-Agent: curl/7.35.0
  > Host: 127.0.0.1:8000
  > Accept: _/_
  > Date: Tue, 08 Mar 2016 08:27:18 +0000
  > Authorization: AWS 0ef217eff5b146f19759532d3b6ea76a:LpagvRo2e/Q6NRdNnI5l84ub/4U=
  >
  < HTTP/1.1 200 OK
  < x-jcs-request-id: tx00000000000000000012c-0056de8ce6-1022-default
  < Content-Type: application/xml
  < Content-Length: 241
  < Date: Tue, 08 Mar 2016 08:27:18 GMT
  <
- Connection #0 to host 127.0.0.1 left intact
  <?xml version="1.0" encoding="UTF-8"?><ListAllMyBucketsResult xmlns="https://dss.ind-west-1.staging.jiocloudservices.com"><Owner><ID>304018976221</ID><DisplayName>304018976221</DisplayName></Owner><Buckets></Buckets></ListAllMyBucketsResult>root@vm-mac0 ~: 
  root@vm-mac0 ~: 
  root@vm-mac0 ~: 
  root@vm-mac0 ~: vim dsscurl_raj.pl
  root@vm-mac0 ~: perl ./dsscurl_raj.pl --id=iam_user_00 -- http://127.0.0.1:8000
  StringToSign='GET

Tue, 08 Mar 2016 08:29:50 +0000
/'
==========exec curl -v -H Date: Tue, 08 Mar 2016 08:29:50 +0000 -H Authorization: JCS 0ef217eff5b146f19759532d3b6ea76a:6Es3mi35/LAYW1rsVa9oEnwQ7HA= -L -H content-type:  http://127.0.0.1:8000
==========\* Rebuilt URL to: http://127.0.0.1:8000/
- Hostname was NOT found in DNS cache
-   Trying 127.0.0.1...
- Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
  > GET / HTTP/1.1
  > User-Agent: curl/7.35.0
  > Host: 127.0.0.1:8000
  > Accept: _/_
  > Date: Tue, 08 Mar 2016 08:29:50 +0000
  > Authorization: JCS 0ef217eff5b146f19759532d3b6ea76a:6Es3mi35/LAYW1rsVa9oEnwQ7HA=
  >
  < HTTP/1.1 200 OK
  < x-jcs-request-id: tx00000000000000000012d-0056de8d7e-1022-default
  < Content-Type: application/xml
  < Content-Length: 241
  < Date: Tue, 08 Mar 2016 08:29:50 GMT
  <
- Connection #0 to host 127.0.0.1 left intact
  <?xml version="1.0" encoding="UTF-8"?><ListAllMyBucketsResult xmlns="https://dss.ind-west-1.staging.jiocloudservices.com"><Owner><ID>304018976221</ID><DisplayName>304018976221</DisplayName></Owner><Buckets></Buckets></ListAllMyBucketsResult>root@vm-mac0 ~: 
  root@vm-mac0 ~: 

2016-03-08 08:27:18.488111 7f775ffff700 20 HTTP_ACCEPT=_/_
2016-03-08 08:27:18.488124 7f775ffff700 20 HTTP_AUTHORIZATION=AWS 0ef217eff5b146f19759532d3b6ea76a:LpagvRo2e/Q6NRdNnI5l84ub/4U=
2016-03-08 08:27:18.488129 7f775ffff700 20 HTTP_DATE=Tue, 08 Mar 2016 08:27:18 +0000
2016-03-08 08:27:18.488134 7f775ffff700 20 HTTP_HOST=127.0.0.1:8000
2016-03-08 08:27:18.488140 7f775ffff700 20 HTTP_USER_AGENT=curl/7.35.0
2016-03-08 08:27:18.488145 7f775ffff700 20 QUERY_STRING=
2016-03-08 08:27:18.488150 7f775ffff700 20 REMOTE_USER=
2016-03-08 08:27:18.488155 7f775ffff700 20 REQUEST_METHOD=GET
2016-03-08 08:27:18.488160 7f775ffff700 20 REQUEST_URI=/
2016-03-08 08:27:18.488164 7f775ffff700 20 SCRIPT_URI=/
2016-03-08 08:27:18.488169 7f775ffff700 20 SERVER_PORT=8000
2016-03-08 08:27:18.488200 7f775ffff700  1 ====== starting new request trans=tx00000000000000000012c-0056de8ce6-1022-default =====
2016-03-08 08:27:18.488208 7f775ffff700 10 host=127.0.0.1
2016-03-08 08:27:18.488214 7f775ffff700 20 subdomain= domain= in_hosted_domain=0
2016-03-08 08:27:18.488263 7f775ffff700 10 s->object=<NULL> s->bucket=<NULL>
2016-03-08 08:27:18.488280 7f775ffff700  2 req 300:0.000101:s3:GET /::getting op
2016-03-08 08:27:18.488294 7f775ffff700  2 req 300:0.000115:s3:GET /:list_buckets:authorizing
2016-03-08 08:27:18.488305 7f775ffff700 20 DSS INFO: keystone: trying keystone auth
2016-03-08 08:27:18.488347 7f775ffff700 10 get_canon_resource(): dest=/
2016-03-08 08:27:18.488371 7f775ffff700  0 DSS INFO: Sending Action to validate: ListAllMyBuckets
2016-03-08 08:27:18.488382 7f775ffff700  0 DSS INFO: Sending Resource to validate: *
2016-03-08 08:27:18.488389 7f775ffff700  0 DSS INFO: Sending Tenant to validate:
2016-03-08 08:27:18.488399 7f775ffff700  0 DSS INFO: Action string: jrn:jcs:dss:ListAllMyBuckets
2016-03-08 08:27:18.488404 7f775ffff700  0 DSS INFO: Resource string: jrn:jcs:dss::Bucket:*
2016-03-08 08:27:18.488409 7f775ffff700  0 DSS INFO: Final URL: https://iam.ind-west-1.staging.jiocloudservices.com:35357/v3/sign-auth
2016-03-08 08:27:18.488490 7f775ffff700  0 DSS INFO: Signature: LpagvRo2e/Q6NRdNnI5l84ub/4U=
2016-03-08 08:27:18.488497 7f775ffff700  0 DSS INFO: Canonical str: R0VUCgoKVHVlLCAwOCBNYXIgMjAxNiAwODoyNzoxOCArMDAwMAov
2016-03-08 08:27:18.488562 7f775ffff700  0 DSS INFO: Outbound json: {"credentials":{"access":"0ef217eff5b146f19759532d3b6ea76a","token":"R0VUCgoKVHVlLCAwOCBNYXIgMjAxNiAwODoyNzoxOCArMDAwMAov","signature":"LpagvRo2e\/Q6NRdNnI5l84ub\/4U=","action_resource_list":[{"action":"jrn:jcs:dss:ListAllMyBuckets","resource":"jrn:jcs:dss::Bucket:_","implicit_allow":"False"}]}}
2016-03-08 08:27:18.488651 7f775ffff700  0 DSS INFO: Actual TX buffer: {"credentials":{"access":"0ef217eff5b146f19759532d3b6ea76a","token":"R0VUCgoKVHVlLCAwOCBNYXIgMjAxNiAwODoyNzoxOCArMDAwMAov","signature":"LpagvRo2e\/Q6NRdNnI5l84ub\/4U=","action_resource_list":[{"action":"jrn:jcs:dss:ListAllMyBuckets","resource":"jrn:jcs:dss::Bucket:_","implicit_allow":"False"}]}}
2016-03-08 08:27:18.488973 7f775ffff700 20 RGWHTTPClient::process sending request to https://iam.ind-west-1.staging.jiocloudservices.com:35357/v3/sign-auth
2016-03-08 08:27:18.488983 7f775ffff700  0 DSS INFO: IAM request header: Content-Type : application/json
2016-03-08 08:27:18.715444 7f775ffff700  0 DSS INFO: Keystone response time (milliseconds): 108
2016-03-08 08:27:18.715496 7f775ffff700  0 DSS INFO: Printing RX buffer: {"token_id": "d25d71f7200846dcabe1bb3c91024e41", "user_id": "c9b6097a56c04516b638c6128e456cdd", "account_id": "304018976221", "user_type": "root"}Tw
2016-03-08 08:27:18.715503 7f775ffff700  0 DSS INFO: Printing RX headers: HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Date: Tue, 08 Mar 2016 08:25:38 GMT
Server: Apache/2.4.7 (Ubuntu)
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: Accept, Content-Type, X-Auth-Token, X-Subject-Token
Access-Control-Expose-Headers: Accept, Content-Type, X-Auth-Token, X-Subject-Token
Access-Control-Allow-Methods: GET POST OPTIONS PUT DELETE PATCH
Vary: X-Auth-Token
Content-Type: application/json
Content-Length: 146
X-Openstack-Request-Id: req-b8766bd9-837b-47b9-95f8-dfeeb197c54b
Via: 1.1 iam.ind-west-1.staging.jiocloudservices.com:35357
Connection: close

2016-03-08 08:27:18.715619 7f775ffff700  5 DSS INFO: keystone validated signature for (root account id : user id) 304018976221:c9b6097a56c04516b638c6128e456cdd

2016-03-08 08:29:50.641913 7f777f7fe700 20 SERVER_PORT=8000
2016-03-08 08:29:50.641918 7f777f7fe700 20 RGWEnv::set(): HTTP_USER_AGENT: curl/7.35.0
2016-03-08 08:29:50.641931 7f777f7fe700 20 RGWEnv::set(): HTTP_HOST: 127.0.0.1:8000
2016-03-08 08:29:50.641936 7f777f7fe700 20 RGWEnv::set(): HTTP_ACCEPT: _/_
2016-03-08 08:29:50.641941 7f777f7fe700 20 RGWEnv::set(): HTTP_DATE: Tue, 08 Mar 2016 08:29:50 +0000
2016-03-08 08:29:50.641945 7f777f7fe700 20 RGWEnv::set(): HTTP_AUTHORIZATION: JCS 0ef217eff5b146f19759532d3b6ea76a:6Es3mi35/LAYW1rsVa9oEnwQ7HA=
2016-03-08 08:29:50.641949 7f777f7fe700 20 RGWEnv::set(): REQUEST_METHOD: GET
2016-03-08 08:29:50.641953 7f777f7fe700 20 RGWEnv::set(): REQUEST_URI: /
2016-03-08 08:29:50.641956 7f777f7fe700 20 RGWEnv::set(): QUERY_STRING:
2016-03-08 08:29:50.641960 7f777f7fe700 20 RGWEnv::set(): REMOTE_USER:
2016-03-08 08:29:50.642013 7f777f7fe700 20 RGWEnv::set(): SCRIPT_URI: /
2016-03-08 08:29:50.642018 7f777f7fe700 20 RGWEnv::set(): SERVER_PORT: 8000
2016-03-08 08:29:50.642024 7f777f7fe700 20 HTTP_ACCEPT=_/_
2016-03-08 08:29:50.642029 7f777f7fe700 20 HTTP_AUTHORIZATION=JCS 0ef217eff5b146f19759532d3b6ea76a:6Es3mi35/LAYW1rsVa9oEnwQ7HA=
2016-03-08 08:29:50.642035 7f777f7fe700 20 HTTP_DATE=Tue, 08 Mar 2016 08:29:50 +0000
2016-03-08 08:29:50.642039 7f777f7fe700 20 HTTP_HOST=127.0.0.1:8000
2016-03-08 08:29:50.642044 7f777f7fe700 20 HTTP_USER_AGENT=curl/7.35.0
2016-03-08 08:29:50.642050 7f777f7fe700 20 QUERY_STRING=
2016-03-08 08:29:50.642055 7f777f7fe700 20 REMOTE_USER=
2016-03-08 08:29:50.642060 7f777f7fe700 20 REQUEST_METHOD=GET
2016-03-08 08:29:50.642065 7f777f7fe700 20 REQUEST_URI=/
2016-03-08 08:29:50.642070 7f777f7fe700 20 SCRIPT_URI=/
2016-03-08 08:29:50.642075 7f777f7fe700 20 SERVER_PORT=8000
2016-03-08 08:29:50.642104 7f777f7fe700  1 ====== starting new request trans=tx00000000000000000012d-0056de8d7e-1022-default =====
2016-03-08 08:29:50.642112 7f777f7fe700 10 host=127.0.0.1
2016-03-08 08:29:50.642118 7f777f7fe700 20 subdomain= domain= in_hosted_domain=0
2016-03-08 08:29:50.642168 7f777f7fe700 10 s->object=<NULL> s->bucket=<NULL>
2016-03-08 08:29:50.642195 7f777f7fe700  2 req 301:0.000110:s3:GET /::getting op
2016-03-08 08:29:50.642208 7f777f7fe700  2 req 301:0.000124:s3:GET /:list_buckets:authorizing
2016-03-08 08:29:50.642218 7f777f7fe700 20 DSS INFO: keystone: trying keystone auth
2016-03-08 08:29:50.642262 7f777f7fe700 10 get_canon_resource(): dest=/
2016-03-08 08:29:50.642289 7f777f7fe700  0 DSS INFO: Sending Action to validate: ListAllMyBuckets
2016-03-08 08:29:50.642296 7f777f7fe700  0 DSS INFO: Sending Resource to validate: *
2016-03-08 08:29:50.642301 7f777f7fe700  0 DSS INFO: Sending Tenant to validate:
2016-03-08 08:29:50.642311 7f777f7fe700  0 DSS INFO: Action string: jrn:jcs:dss:ListAllMyBuckets
2016-03-08 08:29:50.642316 7f777f7fe700  0 DSS INFO: Resource string: jrn:jcs:dss::Bucket:*
2016-03-08 08:29:50.642321 7f777f7fe700  0 DSS INFO: Final URL: https://iam.ind-west-1.staging.jiocloudservices.com:35357/v3/sign-auth
2016-03-08 08:29:50.642408 7f777f7fe700  0 DSS INFO: Signature: 6Es3mi35/LAYW1rsVa9oEnwQ7HA=
2016-03-08 08:29:50.642416 7f777f7fe700  0 DSS INFO: Canonical str: R0VUCgoKVHVlLCAwOCBNYXIgMjAxNiAwODoyOTo1MCArMDAwMAov
2016-03-08 08:29:50.642467 7f777f7fe700  0 DSS INFO: Outbound json: {"credentials":{"access":"0ef217eff5b146f19759532d3b6ea76a","token":"R0VUCgoKVHVlLCAwOCBNYXIgMjAxNiAwODoyOTo1MCArMDAwMAov","signature":"6Es3mi35\/LAYW1rsVa9oEnwQ7HA=","action_resource_list":[{"action":"jrn:jcs:dss:ListAllMyBuckets","resource":"jrn:jcs:dss::Bucket:_","implicit_allow":"False"}]}}
2016-03-08 08:29:50.642475 7f777f7fe700  0 DSS INFO: Actual TX buffer: {"credentials":{"access":"0ef217eff5b146f19759532d3b6ea76a","token":"R0VUCgoKVHVlLCAwOCBNYXIgMjAxNiAwODoyOTo1MCArMDAwMAov","signature":"6Es3mi35\/LAYW1rsVa9oEnwQ7HA=","action_resource_list":[{"action":"jrn:jcs:dss:ListAllMyBuckets","resource":"jrn:jcs:dss::Bucket:_","implicit_allow":"False"}]}}
2016-03-08 08:29:50.644197 7f777f7fe700 20 RGWHTTPClient::process sending request to https://iam.ind-west-1.staging.jiocloudservices.com:35357/v3/sign-auth
2016-03-08 08:29:50.644206 7f777f7fe700  0 DSS INFO: IAM request header: Content-Type : application/json
2016-03-08 08:29:50.865058 7f777f7fe700  0 DSS INFO: Keystone response time (milliseconds): 111
2016-03-08 08:29:50.865184 7f777f7fe700  0 DSS INFO: Printing RX buffer: {"token_id": "7fa1b68db57744da8e4cdd558b582b33", "user_id": "c9b6097a56c04516b638c6128e456cdd", "account_id": "304018976221", "user_type": "root"}dw
2016-03-08 08:29:50.865199 7f777f7fe700  0 DSS INFO: Printing RX headers: HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Date: Tue, 08 Mar 2016 08:28:10 GMT
Server: Apache/2.4.7 (Ubuntu)
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: Accept, Content-Type, X-Auth-Token, X-Subject-Token
Access-Control-Expose-Headers: Accept, Content-Type, X-Auth-Token, X-Subject-Token
Access-Control-Allow-Methods: GET POST OPTIONS PUT DELETE PATCH
Vary: X-Auth-Token
Content-Type: application/json
Content-Length: 146
X-Openstack-Request-Id: req-7fe7edd2-ca8b-4bf1-9e29-8aa8e9ee113b
Via: 1.1 iam.ind-west-1.staging.jiocloudservices.com:35357
Connection: close

2016-03-08 08:29:50.865307 7f777f7fe700  5 DSS INFO: keystone validated signature for (root account id : user id) 304018976221:c9b6097a56c04516b638c6128e456cdd
