### PR TITLE
Final rename review. Mergeable.

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1077,6 +1077,11 @@ OPTION(rgw_keystone_token_api, OPT_STR, "v3/token-auth")  // api to validate tok
 OPTION(rgw_keystone_url_token_api, OPT_STR, "url-auth")   // api to validate presigned token URL based authentication requests
 OPTION(rgw_keystone_infinite_url_token_api, OPT_STR, "preauth-token-auth")   // api to validate infinite time presigned token URL
 OPTION(dss_regional_url, OPT_STR, "https://dss.ind-west-1.staging.jiocloudservices.com") // URL to be returned in XMLNS during anonymous list all buckets calls
+OPTION(rgw_enable_rename_op, OPT_BOOL, true)                    // Enable the atomic rename op
+OPTION(fault_inj_rename_op_copy_fail, OPT_BOOL, false)          // Injects fault in rename op during copy operation
+OPTION(fault_inj_rename_op_delete_fail, OPT_BOOL, false)        // Injects fault in rename op during delete operation
+OPTION(fault_inj_rename_op_parse_fail, OPT_BOOL, false)         // Injects fault in rename op during parse operation
+OPTION(fault_inj_rename_op_sleep_after_copy, OPT_BOOL, false)   // Make rename op sleep after copy
 
 OPTION(mutex_perf_counter, OPT_BOOL, false) // enable/disable mutex perf counter
 OPTION(throttler_perf_counter, OPT_BOOL, true) // enable/disable throttler perf counter

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -146,6 +146,14 @@ using ceph::crypto::MD5;
 #define ERR_SIGNATURE_NO_MATCH   2027
 #define ERR_INVALID_ACCESS_KEY   2028
 #define ERR_BUCKET_ALREADY_OWNED 2029
+#define ERR_BAD_RENAME_REQ       2030
+#define ERR_RENAME_NOT_ENABLED   2031
+#define ERR_RENAME_FAILED        2032
+#define ERR_RENAME_DATA_LOST     2033
+#define ERR_RENAME_COPY_FAILED   2034
+#define ERR_RENAME_NEW_OBJ_DEL_FAILED     2035
+#define ERR_RENAME_FAULT_INJ     2036
+#define ERR_RENAME_OBJ_EXISTS    2037
 #define ERR_USER_SUSPENDED       2100
 #define ERR_INTERNAL_ERROR       2200
 
@@ -943,6 +951,11 @@ struct rgw_obj_key {
   void transform(cls_rgw_obj_key *k) {
     k->name = name;
     k->instance = instance;
+  }
+
+  void dss_duplicate(rgw_obj_key* k) {
+    name = k->name;
+    instance = k->instance;
   }
 
   void set(const string& n) {

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -45,6 +45,11 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
     { ERR_USER_SUSPENDED, 403, "UserSuspended" },
     { ERR_REQUEST_TIME_SKEWED, 403, "RequestTimeTooSkewed" ,"The difference between the request time and the server's time is too large."},
     { ERR_QUOTA_EXCEEDED, 403, "QuotaExceeded" },
+    { ERR_BAD_RENAME_REQ, 403, "BadRenameRequest", "Rename request must have object name, new object name and the HTTP method should be PUT."},
+    { ERR_RENAME_NOT_ENABLED, 403, "RenameDisabled", "Rename operation is not enabled"},
+    { ERR_RENAME_FAULT_INJ, 403, "FaultInjection", "A rename operation tester fault has been activated"},
+    { ERR_RENAME_FAILED, 403, "RenameFailed", "Rename operation has failed."},
+    { ERR_RENAME_OBJ_EXISTS, 403, "ObjectExists", "Rename operation cannot continue as the target object already exists."},
     { ENOENT, 404, "NoSuchKey", "Resource not found."},
     { ERR_NO_SUCH_BUCKET, 404, "NoSuchBucket", "Resource not found"},
     { ERR_NO_SUCH_UPLOAD, 404, "NoSuchUpload", "The specified multipart upload does not exist. The upload ID might be invalid, or the multipart upload might have been aborted or completed."},
@@ -58,6 +63,9 @@ const static struct rgw_http_errors RGW_HTTP_ERRORS[] = {
     { ERR_UNPROCESSABLE_ENTITY, 422, "UnprocessableEntity" },
     { ERR_LOCKED, 423, "Locked" },
     { ERR_INTERNAL_ERROR, 500, "InternalError", "We encountered an internal error. Please try again." },
+    { ERR_RENAME_COPY_FAILED, 500, "RenameFailed", "Object copy failed during rename. Please file a bug." },
+    { ERR_RENAME_DATA_LOST, 500, "DataLost", "Rename operation lost the original data. Please file a bug." },
+    { ERR_RENAME_NEW_OBJ_DEL_FAILED, 500, "RenameFailed", "Rename operation failed. Please delete the duplicated object with name same as new name for the object, manually. Please file a bug." },
 };
 
 const static struct rgw_http_errors RGW_HTTP_SWIFT_ERRORS[] = {

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -582,9 +582,9 @@ static int process_request(RGWRados *store, RGWREST *rest, RGWRequest *req, RGWC
 
   if(
       (
-        (amz_metadata_directive != NULL && !strcmp(amz_metadata_directive, "COPY")) 
+        (amz_metadata_directive != NULL && !strcmp(amz_metadata_directive, "COPY"))
         || (jcs_metadata_directive != NULL && !strcmp(jcs_metadata_directive, "COPY"))
-      ) 
+      )
       &&
       (amz_copy_source != NULL || jcs_copy_source != NULL)
     ) {
@@ -596,7 +596,6 @@ static int process_request(RGWRados *store, RGWREST *rest, RGWRequest *req, RGWC
        (s->auth_method).set_copy_source(jcs_copy_source);
     }
   }
-
 
   RGWOp *op = NULL;
   int init_error = 0;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3,9 +3,9 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include <sstream>
-
 #include "common/Clock.h"
 #include "common/armor.h"
 #include "common/mime.h"
@@ -24,7 +24,7 @@
 #include "rgw_multi_del.h"
 #include "rgw_cors.h"
 #include "rgw_cors_s3.h"
-
+#include "rgw_rest_s3.h"
 #include "rgw_client_io.h"
 
 #define dout_subsys ceph_subsys_rgw
@@ -3514,3 +3514,228 @@ void RGWHandler::put_op(RGWOp *op)
   delete op;
 }
 
+
+
+/* Object Rename operation */
+
+int RGWRenameObj::verify_permission()
+{
+    // This function used to check ACLs in legacy code
+    // DSS does not require this.
+    return 0;
+}
+
+void RGWRenameObj::pre_exec()
+{
+  rgw_bucket_object_pre_exec(s);
+}
+
+void RGWRenameObj::execute()
+{
+    ret = 0;
+    s->err.ret = 0;
+    rgw_obj_key orig_object, new_obj;
+    orig_object.dss_duplicate(&(s->object));
+
+    /* Check if the original object exists */
+    ret = check_obj(orig_object);
+    if (ret < 0) {
+        // The passed original object does not exist
+        s->err.ret = ret;
+        return;
+    }
+
+    /* Tweek request params to make this a copy request */
+    (s->object).name = s->info.args.get("newname");
+    ret = check_obj(s->object);
+    if (ret >= 0) {
+        ldout(s->cct, 0) << "DSS ERROR: Target object already exists." << dendl;
+        s->err.http_ret = 403;
+        s->err.ret = -ERR_RENAME_OBJ_EXISTS;
+        return;
+    }
+
+    string copysource = s->bucket_name_str;
+    copysource.append("/");
+    copysource.append(orig_object.name);
+    ldout(s->cct, 0) << "DSS INFO: Converting to copy request. s->object: "
+                     << (s->object).name << ". Copy source: " << copysource << dendl;
+    s->info.env->set("HTTP_X_JCS_COPY_SOURCE", copysource.c_str());
+    s->info.env->set("HTTP_X_JCS_METADATA_DIRECTIVE", "COPY");
+    s->copy_source = s->info.env->get("HTTP_X_JCS_COPY_SOURCE");
+    if (s->copy_source) {
+      ret = RGWCopyObj::parse_copy_location(s->copy_source, s->src_bucket_name, s->src_object);
+      if (!ret || (store->ctx()->_conf->fault_inj_rename_op_parse_fail)) {
+        ldout(s->cct, 0) << "DSS INFO: Rename op failed to parse copy location" << dendl;
+        s->err.http_ret = 403;
+        s->err.ret = -ERR_RENAME_FAULT_INJ;
+        return;
+      }
+    }
+
+    /* Perform copy operation */
+    RGWCopyObj_ObjStore_S3* copy_op = new RGWCopyObj_ObjStore_S3;
+
+    // Fault injection
+    if (!(store->ctx()->_conf->fault_inj_rename_op_copy_fail)) {
+        perform_external_op(copy_op);
+    } else {
+        s->err.http_ret = 403;
+        s->err.ret = -ERR_RENAME_FAULT_INJ;
+    }
+
+    if ((store->ctx()->_conf->fault_inj_rename_op_sleep_after_copy)) {
+        // Fault injection to test atomicity
+        sleep(60);
+    }
+
+    if ((s->err.http_ret != 200) ||
+        (s->err.ret != 0)) {
+        ldout(s->cct, 0) << "DSS ERROR: Copy object failed during rename op."
+                         << " Return status: " << s->err.ret
+                         << " Return HTTP code: " << s->err.http_ret
+                         << dendl;
+        if (!(store->ctx()->_conf->fault_inj_rename_op_copy_fail)) {
+            // Cause otherwise its us who set that message to ERR_RENAME_FAULT_INJ
+            s->err.ret = -ERR_RENAME_FAILED;
+            s->err.http_ret = 400;
+        }
+        return;
+    }
+    ldout(s->cct, 0) << "DSS INFO: Rename op: copy done" << dendl;
+
+    /* Tweek the request for a delete obj operation and perform delete op */
+    new_obj.dss_duplicate(&(s->object));
+    (s->object).dss_duplicate(&orig_object);
+    RGWDeleteObj_ObjStore_S3* del_op = new RGWDeleteObj_ObjStore_S3;
+
+    // Fault injection
+    if (!(store->ctx()->_conf->fault_inj_rename_op_delete_fail)) {
+        delete_rgw_object(del_op);
+    } else {
+        s->err.http_ret = 403;
+        s->err.ret = -ERR_RENAME_FAULT_INJ;
+    }
+
+    if ((s->err.http_ret != 200) ||
+        (s->err.ret != 0)) {
+        ldout(s->cct, 0) << "DSS ERROR: Delete object failed during rename op."
+                         << " Return status: " << s->err.ret
+                         << " Return HTTP code: " << s->err.http_ret
+                         << dendl;
+
+        /* Revert the copy op */
+        int ret_orig, ret_newobj;
+        ret_orig = check_obj(s->object);
+        ret_newobj = check_obj(new_obj);
+        if (ret_orig < 0) {
+            // Delete failed but we don't have original object!!
+            if (ret_newobj < 0) {
+                // We are in a soup. Data lost. This is not the case we will ever end up in.
+                s->err.ret = -ERR_RENAME_DATA_LOST;
+                s->err.http_ret = 500;
+            } else {
+                // Everything normal
+                if (!store->ctx()->_conf->fault_inj_rename_op_delete_fail) {
+                    s->err.http_ret = 200;
+                    s->err.ret = 0;
+                }
+            }
+        } else {
+            if (ret_newobj >= 0) {
+                // Delete the new object
+                (s->object).dss_duplicate(&new_obj);
+                RGWDeleteObj_ObjStore_S3* ndel_op = new RGWDeleteObj_ObjStore_S3;
+                delete_rgw_object(ndel_op);
+
+                if ((s->err.http_ret != 200) ||
+                    (s->err.ret != 0)) {
+                    ldout(s->cct, 0) << "DSS INFO: New object del failed. Status: "
+                                     << s->err.http_ret << " Ret: " << s->err.ret << dendl;
+                    s->err.ret = -ERR_RENAME_NEW_OBJ_DEL_FAILED;
+                    s->err.http_ret = 500;
+                } else {
+                    // Indicate that there has been a failure
+                    s->err.ret = -ERR_RENAME_FAILED;
+                    s->err.http_ret = 403;
+                    ldout(s->cct, 0) << "DSS INFO: Taking the right route" << dendl;
+                }
+            } else {
+                // Log major error. Ask user to file a bug. Why didn't copy fail?
+                s->err.ret = -ERR_RENAME_COPY_FAILED;
+                s->err.http_ret = 500;
+            }
+        }
+        return;
+    }
+    ldout(s->cct, 0) << "DSS INFO: Rename op complete" << dendl;
+    return;
+}
+
+void RGWRenameObj::perform_external_op(RGWOp* bp)
+{
+    bool failure = false;
+    bp->init(store, s, dialect_handler);
+
+    ret = bp->init_processing();
+    if (ret < 0) {
+        failure = true;
+    } else {
+        ret = bp->verify_op_mask();
+    }
+    if (ret < 0) {
+        failure = true;
+    } else {
+        ret = bp->verify_permission();
+    }
+    if (ret < 0) {
+        failure = true;
+    } else {
+        ret = bp->verify_params();
+    }
+    if (ret < 0) {
+        failure = true;
+    }
+
+    if (!failure) {
+        s->system_request = true;
+        bp->pre_exec();
+        bp->execute();
+        s->system_request = false;
+        s->err.ret = bp->get_request_state()->err.ret;
+        s->err.http_ret = bp->get_request_state()->err.http_ret;
+    } else {
+        s->err.ret = ret;
+    }
+    s->err.ret = bp->get_request_state()->err.ret;
+    s->err.http_ret = bp->get_request_state()->err.http_ret;
+}
+
+int RGWRenameObj::check_obj(rgw_obj_key& object)
+{
+    rgw_obj lobj(s->bucket, object);
+    RGWObjectCtx obj_ctx(store);
+    RGWObjState *ros = NULL;
+
+    ret = store->get_obj_state(&obj_ctx, lobj, &ros, NULL);
+    if (ret < 0) {
+        ldout(s->cct, 0) << "DSS ERROR: Failed to fetch obj state" << dendl;
+        return ret;
+    }
+
+    if (!ros->exists) {
+        ldout(s->cct, 0) << "DSS ERROR: The object " << object.name << " does not exist." << dendl;
+        return -ENOENT;
+    }
+    return 0;
+}
+
+void RGWRenameObj::delete_rgw_object(RGWOp* del_op)
+{
+    ldout(s->cct, 0) << "DSS INFO: Deleting object. s->object.name: "
+                     << (s->object).name << dendl;
+    s->err.http_ret = 200;
+    s->err.ret = 0;
+    perform_external_op(del_op);
+    return;
+}

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -87,7 +87,9 @@ public:
 
     return 0;
   }
-
+  req_state* get_request_state() {
+    return s;
+  }
   virtual void init(RGWRados *store, struct req_state *s, RGWHandler *dialect_handler) {
     this->store = store;
     this->s = s;
@@ -566,14 +568,17 @@ public:
 };
 
 class RGWRenameObj : public RGWOp {
-    //<<<<
     public:
-      RGWRenameObj() {}
+      int ret;
+      RGWRenameObj() : ret(0) {}
       ~RGWRenameObj() {}
-      int verify_permission() { return 0; }
-      void pre_exec() { int x; }
-      void execute() { int x; }
-      const string name() { return "Rename_obj"; }
+      int verify_permission();
+      void pre_exec();
+      void execute();
+      void perform_external_op(RGWOp*);
+      void delete_rgw_object(RGWOp*);
+      int check_obj(rgw_obj_key&);
+      virtual const string name() { return "Rename_obj"; }
 };
 
 class RGWCopyObj : public RGWOp {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -565,6 +565,17 @@ public:
   virtual uint32_t op_mask() { return RGW_OP_TYPE_DELETE; }
 };
 
+class RGWRenameObj : public RGWOp {
+    //<<<<
+    public:
+      RGWRenameObj() {}
+      ~RGWRenameObj() {}
+      int verify_permission() { return 0; }
+      void pre_exec() { int x; }
+      void execute() { int x; }
+      const string name() { return "Rename_obj"; }
+};
+
 class RGWCopyObj : public RGWOp {
 protected:
   RGWAccessControlPolicy dest_policy;

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -188,6 +188,12 @@ public:
   ~RGWCopyObj_ObjStore() {}
 };
 
+class RGWRenameObj_ObjStore : public RGWRenameObj {
+public:
+  RGWRenameObj_ObjStore() {}
+  ~RGWRenameObj_ObjStore() {}
+};
+
 class RGWGetACLs_ObjStore : public RGWGetACLs {
 public:
   RGWGetACLs_ObjStore() {}

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1468,7 +1468,6 @@ done:
   rgw_flush_formatter_and_reset(s, s->formatter);
 }
 
-
 void RGWDeleteObj_ObjStore_S3::send_response()
 {
   int r = ret;
@@ -1617,6 +1616,16 @@ int RGWPutACLs_ObjStore_S3::get_policy_from_state(RGWRados *store, struct req_st
   s3policy.to_xml(ss);
 
   return 0;
+}
+
+void RGWRenameObj_ObjStore_S3::send_response()
+{
+  ret = s->err.ret;
+  if (ret)
+    set_req_state_err(s, ret);
+  dump_errno(s);
+  end_header(s, this, "application/xml");
+  dump_start(s);
 }
 
 void RGWPutACLs_ObjStore_S3::send_response()
@@ -2120,11 +2129,8 @@ RGWOp *RGWHandler_ObjStore_Obj_S3::op_put()
   if (is_acl_op()) {
     return new RGWPutACLs_ObjStore_S3;
   }
-  if (is_rename_op()) {
-    //<<<<<<<<
+  if (store->ctx()->_conf->rgw_enable_rename_op && is_rename_op()) {
     return new RGWRenameObj_ObjStore_S3;
-    //dout(0) << "-------------- The value of new name is " << s->info.args.get("newname") << dendl;
-    //dout(0) << "=========== I am getting rename op =========" << dendl;
   }
   if (!s->copy_source)
     return new RGWPutObj_ObjStore_S3;
@@ -2734,6 +2740,20 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
       return -EPERM;
   }
 
+  // Block rename op for illegal cases
+  if (s->info.args.exists("newname")) {
+      if (!(store->ctx()->_conf->rgw_enable_rename_op)) {
+          return -ERR_RENAME_NOT_ENABLED;
+      }
+      if (s->op == OP_PUT) {
+          if ((s->object).name.empty()) {
+              return -ERR_BAD_RENAME_REQ;
+          }
+      } else {
+          return -ERR_BAD_RENAME_REQ;
+      }
+  }
+
   /* neither keystone and rados enabled; warn and exit! */
   if (!store->ctx()->_conf->rgw_s3_auth_use_rados
       && !store->ctx()->_conf->rgw_s3_auth_use_keystone) {
@@ -2763,10 +2783,9 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
               qsr = true;
           } else {
               /* anonymous access */
-              //<<<<<< You will hit here for sign based req
-              //<<<<<< Add changes for anonymous access. Call a func from here.
-              init_anon_user(s);
-              return 0;
+              return -EPERM;
+              //init_anon_user(s);
+              //return 0;
           }
       } else {
           // strncmp returns 0 on match. If even one of AWS or JCS match, dont return -EINVAL.
@@ -2814,7 +2833,11 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
       if (s != NULL) {
           resource_object_name = s->object.name;
       }
-      dout(1) << "DSS API LOGGING: Action="<< resource_info.getAction() <<"        Resource="<< resource_info.getResourceName() << "        Tenant=" << resource_info.getTenantName() << "        Object=" << resource_object_name << dendl;
+      dout(1) << "DSS API LOGGING: Action="
+              << resource_info.getAction()
+              << "        Resource="<< resource_info.getResourceName()
+              << "        Tenant=" << resource_info.getTenantName()
+              << "        Object=" << resource_object_name << dendl;
 
       if (isTokenBasedAuth) {
           keystone_result = keystone_validator.validate_request(resource_info.getAction(),
@@ -2832,7 +2855,7 @@ int RGW_Auth_S3::authorize(RGWRados *store, struct req_state *s)
                                                                 "",  /* Received signature */
                                                                 resource_object_name,
                                                                 iamerror);
-        
+
       } else {
           keystone_result = keystone_validator.validate_request(resource_info.getAction(),
                                                                 resource_info.getResourceName(),

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1238,7 +1238,7 @@ int RGWPostObj_ObjStore_S3::get_policy()
                 return -EACCES;
             }
             user_info.user_id = keystone_validator.response.token.tenant.id;
-            user_info.display_name = keystone_validator.response.token.tenant.id; //<<<<<< DSS needs tenant.name
+            user_info.display_name = keystone_validator.response.token.tenant.id;
             /* try to store user if it not already exists */
             if (rgw_get_user_info_by_uid(store, keystone_validator.response.token.tenant.id, user_info) < 0) {
                 int ret = rgw_store_user_info(store, user_info, NULL, NULL, 0, true);
@@ -2120,6 +2120,12 @@ RGWOp *RGWHandler_ObjStore_Obj_S3::op_put()
   if (is_acl_op()) {
     return new RGWPutACLs_ObjStore_S3;
   }
+  if (is_rename_op()) {
+    //<<<<<<<<
+    return new RGWRenameObj_ObjStore_S3;
+    //dout(0) << "-------------- The value of new name is " << s->info.args.get("newname") << dendl;
+    //dout(0) << "=========== I am getting rename op =========" << dendl;
+  }
   if (!s->copy_source)
     return new RGWPutObj_ObjStore_S3;
   else
@@ -2397,7 +2403,7 @@ int RGW_Auth_S3_Keystone_ValidateToken::validate_request(const string& action,
                    || is_url_token
                    || is_infini_url_token);
 
-  /* Infinite URLs should only be used for GET <<<<<< Needs discussion */
+  /* Infinite URLs should only be used for GET */
   if (is_infini_url_token && !(
         (localAction.compare("ListBucket") == 0) ||
         (localAction.compare("GetObject") == 0)  ||

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -188,13 +188,11 @@ public:
 };
 
 class RGWRenameObj_ObjStore_S3 : public RGWRenameObj_ObjStore {
-    //<<<<
     public:
-        void send_response() {
-            int y;
-        }
         RGWRenameObj_ObjStore_S3() {}
         ~RGWRenameObj_ObjStore_S3() {}
+
+        void send_response();
 };
 
 class RGWGetACLs_ObjStore_S3 : public RGWGetACLs_ObjStore {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -187,6 +187,16 @@ public:
   void send_response();
 };
 
+class RGWRenameObj_ObjStore_S3 : public RGWRenameObj_ObjStore {
+    //<<<<
+    public:
+        void send_response() {
+            int y;
+        }
+        RGWRenameObj_ObjStore_S3() {}
+        ~RGWRenameObj_ObjStore_S3() {}
+};
+
 class RGWGetACLs_ObjStore_S3 : public RGWGetACLs_ObjStore {
 public:
   RGWGetACLs_ObjStore_S3() {}
@@ -445,6 +455,9 @@ protected:
   }
   bool is_obj_update_op() {
     return is_acl_op();
+  }
+  bool is_rename_op() {
+      return s->info.args.exists("newname");
   }
   RGWOp *get_obj_op(bool get_data);
 


### PR DESCRIPTION
#1. Rename an object

Rename operation requires PutObject permission from IAM. It also requires authentication (token/signature based or presigned URL)
Eg. 
PUT https://www.dss.com/bucket/objname?newname=newobj
- Rename an object with signature auth -> PASS
- Rename an object with token auth -> PASS
- Rename an object without IAM permissions. This should fail.
#2. Bad rename requests
- Rename an object when bucket does not exists -> PASS
- Rename an object when object does not exists -> PASS
- Try rename op when the HTTP verb is GET/POST etc. Eg. POST https://www.dss.com/validbuck/validobj?newname=newobj. This should fail. -> FAILS
- Disable rename op using ceph.conf option: "rgw enable rename op = false". Try rename. It should fail. -> FAILS
- Have objects file1, file2. Rename file1 to file2. This should fail. -> FAILS
- Rename an object with its own name. Copy fails as a legacy so this should fail. -> FAILS
#3. Fault injection cases

Here are the fault injection options for ceph.conf
1081 OPTION(fault_inj_rename_op_copy_fail, OPT_BOOL, false)          // Injects fault in rename op during copy operation
1082 OPTION(fault_inj_rename_op_delete_fail, OPT_BOOL, false)        // Injects fault in rename op during delete operation
1083 OPTION(fault_inj_rename_op_parse_fail, OPT_BOOL, false)         // Injects fault in rename op during parse operation
1084 OPTION(fault_inj_rename_op_sleep_after_copy, OPT_BOOL, false)   // Make rename op sleep after copy
- Turn copy fault on and try rename. Proper error message should be thrown and original object should stay intact. No ghost object should be present. -> PASS
- Turn delete fault on and try rename. Original should remain. No ghosts. -> PASS
- Turn parse fault on and try rename. Original should remain. No ghosts. -> PASS
