### PR TITLE
Adding allowed headers for console sse

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1065,7 +1065,7 @@ OPTION(rgw_user_max_buckets, OPT_U32, 1000) // global option to set max buckets 
 OPTION(rgw_enable_cors_response_headers, OPT_BOOL, true) // send cors response headers in case of a token based request
 OPTION(rgw_cors_allowed_origin, OPT_STR, "https://console.jiocloudservices.com, http://console.jiocloudservices.com, http://consolepreprod.jiocloudservices.com, https://consolepreprod.jiocloudservices.com, http://console.staging.jiocloudservices.com, https://console.staging.jiocloudservices.com")// cors allowed domains
 OPTION(rgw_cors_allowed_methods, OPT_STR, "GET, PUT, HEAD, POST, DELETE, COPY, OPTIONS") // cors allowed methods
-OPTION(rgw_cors_allowed_headers, OPT_STR, "X-Auth-Token, Content-Disposition, Content-Type") // cors allowed headers
+OPTION(rgw_cors_allowed_headers, OPT_STR, "X-Auth-Token, Content-Disposition, Content-Type, X-Jcs-Server-Side-Encryption") // cors allowed headers
 OPTION(rgw_cors_exposed_headers, OPT_STR, "ETag") // cors explicitely exposed headers
 OPTION(rgw_cors_content_disposition_header, OPT_STR, "Content-Disposition") // cors content disposition HEADER
 OPTION(rgw_cors_content_disposition_header_value, OPT_STR, "attachment") // cors content disposition HEADER value

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -952,7 +952,7 @@ int RGWPutObj_ObjStore::get_data(bufferlist& bl,MD5* hash)
         return r;
       unsigned char* read_data = reinterpret_cast<unsigned char *>(bp.c_str());
       if (hash && read_len)
-        hash->Update((const byte *)bp.c_str(),read_len);
+        hash->Update((const byte *)bp.c_str(),bp.length());
 
       len = read_len;
       unsigned char* ciphertext = new unsigned char[read_len];
@@ -977,7 +977,7 @@ int RGWPutObj_ObjStore::get_data(bufferlist& bl,MD5* hash)
       int read_len; /* cio->read() expects int * */
       int r = s->cio->read(bp.c_str(), cl, &read_len);
       if (hash && read_len)
-        hash->Update((const byte *)bp.c_str(),read_len);
+        hash->Update((const byte *)bp.c_str(),bp.length());
       if (r < 0) {
         return r;
       }


### PR DESCRIPTION
Also a possible fix for rgw crash while calculating MD5 sum. 
